### PR TITLE
fix decimal comma instead of decimal point

### DIFF
--- a/src/patches/ZoomPatch.cs
+++ b/src/patches/ZoomPatch.cs
@@ -45,7 +45,8 @@ public class ZoomPatch : IPatch
 
                     int end = lines[i].IndexOf(')', start);
 
-                    lines[i] = lines[i][..start] + $"CreateCameraZoomNode(1000000, 1000000, {zoomLevel})" + lines[i][(end + 1)..];
+                    string zoomLevelString = zoomLevel.ToString().Replace(',', '.');
+                    lines[i] = lines[i][..start] + $"CreateCameraZoomNode(1000000, 1000000, {zoomLevelString})" + lines[i][(end + 1)..];
                 }
             }
 
@@ -61,7 +62,8 @@ public class ZoomPatch : IPatch
 
             if (index == -1) return text;
 
-            lines.Insert(index + 1, $"\ton_initial_position_set = \"CreateCameraZoomNode(1000000, 1000000, {zoomLevel});\"");
+            string zoomLevelString = zoomLevel.ToString().Replace(',', '.');
+            lines.Insert(index + 1, $"\ton_initial_position_set = \"CreateCameraZoomNode(1000000, 1000000, {zoomLevelString});\"");
 
             return string.Join("\r\n", lines);
         }


### PR DESCRIPTION
Added a decimal comma to decimal point conversion. Some PCs use a decimal comma as default: 
on_initial_position_set = "CreateCameraZoomNode(1000000, 10000000, 1,8);" 

They then encounter [THIS](https://github.com/glutzer/SneedSmoother/issues/2#issue-2436141376) error:

```
Failed to load type "Metadata/Characters/Character.ot" Exception: Expected string argument; found: 8
Failed to load type "Metadata/Characters/Character.ot" Exception: Expected string argument; found: 8
Failed to load type "Metadata/Characters/Dex/Dex.ot" Exception: Expected string argument; found: 8
Failed to load type "Metadata/Characters/Character.ot" Exception: Expected string argument; found: 8
Failed to load type "Metadata/Characters/StrDexInt/StrDexInt.ot" Exception: Expected string argument; found: 8
Failed to load type "Metadata/Characters/Character.ot" Exception: Expected string argument; found: 8
Failed to load type "Metadata/Characters/Str/Str.ot" Exception: Expected string argument; found: 8
Failed to load type "Metadata/Characters/Int/Int.ot" Exception: Expected string argument; found: 8
Failed to load type "Metadata/Characters/Character.ot" Exception: Expected string argument; found: 8
Failed to load type "Metadata/Characters/StrDex/StrDex.ot" Exception: Expected string argument; found: 8
Failed to load type "Metadata/Characters/Character.ot" Exception: Expected string argument; found: 8
Failed to load type "Metadata/Characters/DexInt/DexInt.ot" Exception: Expected string argument; found: 8
Failed to load type "Metadata/Characters/Character.ot" Exception: Expected string argument; found: 8
Failed to load type "Metadata/Characters/StrInt/StrInt.ot" Exception: Expected string argument; found: 8
```

There are probably multiple ways to fix this, but converting any "," to "." in zoomLevel seems to fix it for me.